### PR TITLE
Firefox Fix! (testing needed)

### DIFF
--- a/app/assets/javascripts/player.js
+++ b/app/assets/javascripts/player.js
@@ -8,12 +8,10 @@ var Player = {
     //incoming ugly fix for YT not firing onReady if the player element is hidden
     if($.browser.mozilla) {
       tag.onload = function() {
-        setTimeout(function() {
-          if (!$("#player").is(':visible')) {
-            $('#loading-playlist').hide();
-            $('#player').show(0, function(){$('#player').hide();});
-          }
-        }, 2000);
+        if (!$("#player").is(':visible')) {
+          $('#loading-playlist').hide();
+          $('#player').show();
+        }
       }
     }
     var firstScriptTag = document.getElementsByTagName('script')[0];


### PR DESCRIPTION
## YO FIREFOX, WHAT UP?

So, if you load tubalr in firefox, you'll see that it doesn't work correctly after typing a search and submitting it.  After submitting a search, when you're sitting at the 'loading...' blurb with nothing going on,  if you inspect the #player element and unhide it (uncheck 'display: none'), you'll see things magically come to life. I discovered that when trying to figure out why the onReady callback of the YT.Player wasn't firing.
### long story short

I think the onReady callback for YT Player doesn't fire unless the player's element is visible.  Or that's my best guess as to why it was exhibiting dumbass behavior, and my guess as to why my fix works.
### my fix

just checks to see if the browser is firefox, and if it is, it attaches a callback to the script element that loads the player_api from youtube.  when that script is finished, I go ahead and hide the loading text and show the player, _even though_ the player isn't quite ready to be shown yet. Honestly, I only saw that my fix works and submitted this pull request in hopes that someone else could find the flaws in my approach.

peace.
