### PR TITLE
Improved searching for Video IDs

### DIFF
--- a/app/assets/javascripts/playlist.js
+++ b/app/assets/javascripts/playlist.js
@@ -266,20 +266,9 @@ var Playlist = {
         });
       }
       if ( Playlist.options.retainTopID ) {
-      $.ajax({
-        url: 'http://gdata.youtube.com/feeds/api/videos/'+topID+'?alt=json',
-      	async: false,
-      	dataType: 'json',
-      	success: function(data) {
-      		if (Video.isNotBlocked(data.entry) && Video.isNotUserBanned(data.entry) && Video.hasTitle(data.entry)) {
-            videos.push({
-              videoID:    topID,
-              videoTitle: data.entry.title.$t
-            });
-          }
-      	}
-      });
-    }
+        Playlist.options.videoID = topID;
+        Playlist.video();
+      }
       if (options.resultsReady) {
         options.resultsReady()
       }


### PR DESCRIPTION
Hello.
I've improved searching for videos via video ID.
Searching a valid video ID (ex: C0EgzJ0KGxg) and selecting "only" now loads the video ID as the first result, and fills the remaining results with related videos. Useful for adding a specific video to a playlist or finding videos similar to a specific video. Non-embedable youtube videos (ex: Puzy_n3TeIQ) are not loaded but still show related videos.

Related videos are found through the original video's title, so the amount of related videos fluctuates depending on how vague the title is, how long the title is, etc.
